### PR TITLE
Add coverage report to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - gusto/bundle-install
       - run: bundle exec rake
-    - store_artifacts:
-      path: coverage
+      - store_artifacts:
+        path: coverage
   release:
     executor: gusto/ruby-2-3
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - gusto/bundle-install
       - run: bundle exec rake
+    - store_artifacts:
+      path: coverage
   release:
     executor: gusto/ruby-2-3
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - gusto/bundle-install
       - run: bundle exec rake
       - store_artifacts:
-        path: coverage
+          path: coverage
   release:
     executor: gusto/ruby-2-3
     steps:


### PR DESCRIPTION
The report appears under artifacts:

![image](https://user-images.githubusercontent.com/14058109/74986129-d12d8f80-53ed-11ea-95dd-eaf7729d1ad3.png)

Clicking on `index.html` shows the report:
https://242-228663889-gh.circle-artifacts.com/0/coverage/index.html#_AllFiles
![image](https://user-images.githubusercontent.com/14058109/74986211-f3bfa880-53ed-11ea-8cdb-9a35339c6e27.png)

I tried to find a badge for it that we could put on github but there isn't one readily available 😞 