### PR TITLE
feat: Allow RackApp.handle to work with module and block

### DIFF
--- a/spec/unit/grpc_web/server/rack_app_spec.rb
+++ b/spec/unit/grpc_web/server/rack_app_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe(::GRPCWeb::RackApp) do
     end
   end
 
+  shared_context 'given a service module and a lazy init block' do
+    let(:handle) do
+      app.handle(HelloService) do
+        service_cache[:service_class_instance] ||= service_class.new
+      end
+    end
+  end
+
   describe 'validation' do
     subject(:handle) { handle }
 
@@ -64,6 +72,18 @@ RSpec.describe(::GRPCWeb::RackApp) do
       it 'validates the class' do
         expect(::GRPCWeb::ServiceClassValidator).to receive(:validate).with(service_class)
         handle
+      end
+    end
+
+    context 'given a service module and a lazy init block' do
+      include_context 'given a service module and a lazy init block'
+      it 'validates the class' do
+        expect(::GRPCWeb::ServiceClassValidator).to receive(:validate).with(HelloService::Service)
+        handle
+      end
+
+      it 'raises an error' do
+        expect { app.handle(HelloService) }.to raise_error(ArgumentError, 'HelloService is an abstract interface. With an abstract interface you must also provide an initializer block.')
       end
     end
 


### PR DESCRIPTION
This ensures that when a service interface is being passed to handle
it accordingly works/adheres to the same function. Additionally, we
also raise an error when an interface is passed but no block.

This was caught when we were calling the block/proc being passed to handle
(from instrumentation wrapper) and the service classes were getting reloaded
from the initializer. Which is no longer possible start rails 6.

Being able to pass service interface with a block allows us to not reload
classes at the time of init. The additional error raise is future-proofing/guard rails

Adding as a `feat`, so we get a `minor` version bump, instead of a `patch`