### PR TITLE
RR-540: Replace apparition with selenium-webdriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:2.7.8
 # Install dependency packages
 RUN apt-get update && apt-get install -y \
   chromium \
+  chromium-driver \
   curl \
   fonts-liberation \
   libappindicator3-1 \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,11 +11,7 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     ast (2.4.3)
-    base64 (0.2.0)
     bigdecimal (3.1.9)
     byebug (11.1.3)
     capybara (3.39.2)
@@ -52,6 +48,10 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
+    nokogiri (1.15.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.7-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.15.7-arm64-darwin)
@@ -102,6 +102,11 @@ GEM
     rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.13.0)
+    rubyzip (2.4.1)
+    selenium-webdriver (4.9.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -113,20 +118,18 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.7)
-      base64
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
+    websocket (1.2.11)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
 PLATFORMS
   aarch64-linux
   arm64-darwin-24
+  ruby
   x86_64-linux
 
 DEPENDENCIES
-  apparition
+  capybara
   grpc-web!
   pry-byebug
   rack-cors
@@ -134,6 +137,7 @@ DEPENDENCIES
   rspec (~> 3.3)
   rubocop (~> 0.79.0)
   rubocop-rspec
+  selenium-webdriver
   simplecov
   webmock
 

--- a/grpc-web.gemspec
+++ b/grpc-web.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-protobuf', '~> 3.13.0'
   spec.add_dependency 'rack', '>= 1.6.0', '< 3.0'
 
-  spec.add_development_dependency 'apparition'
+  spec.add_development_dependency 'capybara'
+  spec.add_development_dependency 'selenium-webdriver'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rack-cors'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Note that https://github.com/Gusto/grpc-web-ruby/pull/92 also contains this work, though implemented differently.

(I'm not tied to this implementation, but i do think we want to break up that PR.)