### PR TITLE
Add bundler/gem_tasks to Rakefile for release pipeline

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler/gem_tasks'
 require 'rake/clean'
 require 'rspec/core/rake_task'
 


### PR DESCRIPTION
## Summary
- Adds `require 'bundler/gem_tasks'` to the Rakefile, which provides the `rake release` task needed by the release workflow
- Required to make the release build pass: https://github.com/Gusto/grpc-web-ruby/actions/runs/22644707862/job/65629613753

## Test plan
- [ ] Merge, delete the v1.3.0 tag, re-tag, and verify the release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)